### PR TITLE
fixed: raise exception for parse stream when load xmind

### DIFF
--- a/xmind/core/loader.py
+++ b/xmind/core/loader.py
@@ -41,8 +41,8 @@ class WorkbookLoader(object):
                     elif stream == const.COMMENTS_XML:
                         self._comments_steam = utils.parse_dom_string(input_stream.read(stream))
 
-        except BaseException:
-            pass
+        except BaseException as e:
+            raise e
 
     def get_workbook(self):
         """ Parse XMind file to `WorkbookDocument` object and return


### PR DESCRIPTION
如果xmind中有非法字符，就无法获得根节点并且也不报错，希望解析失败的时候将错误抛出，方便排查